### PR TITLE
Allow requests to be authenticated via gcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ The Firebase Admin Rust SDK enables access to Firebase services from privileged 
 
 # Currently supports
 * GCP service accounts
+* `gcloud`'s access token
 * User and custom authentication management
 * Firebase emulator integration and management
 * Firebase OIDC token and session cookie verification using asynchronous public certificate cache

--- a/examples/get_users/src/main.rs
+++ b/examples/get_users/src/main.rs
@@ -26,7 +26,13 @@ where
 
 #[tokio::main]
 async fn main() {
-    // Live Firebase App
+    // Live Firebase App, credentials are loaded from service account or gcloud's token.
+    // For `gcloud` authentication:
+    // ```
+    // gcloud auth login
+    // gcloud config set project <your-project>
+    //```
+    // Please note that the caller must have serviceusage.services.use role.
     let gcp_service_account = credentials_provider().await.unwrap();
 
     let live_app = App::live(gcp_service_account).await.unwrap();

--- a/lib/src/client/mod.rs
+++ b/lib/src/client/mod.rs
@@ -74,13 +74,15 @@ impl<T: Serialize> SetReqBody<T> for reqwest::RequestBuilder {
 pub struct ReqwestApiClient<C> {
     client: reqwest::Client,
     credentials: C,
+    project_id: String,
 }
 
 impl<C: Credentials> ReqwestApiClient<C> {
-    pub fn new(client: reqwest::Client, credentials: C) -> Self {
+    pub fn new(client: reqwest::Client, credentials: C, project_id: String) -> Self {
         Self {
             client,
             credentials,
+            project_id,
         }
     }
 
@@ -117,6 +119,7 @@ impl<C: Credentials> ReqwestApiClient<C> {
                     .change_context(ApiClientError::FailedToSendRequest)?,
             )
             .set_request_body(body)
+            .header("x-goog-user-project", &self.project_id)
             .send()
             .await
             .change_context(ApiClientError::FailedToSendRequest)

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -43,7 +43,11 @@ impl App<EmulatorCredentials> {
 
     /// Firebase authentication manager for emulator
     pub fn auth(&self, emulator_url: String) -> EmulatorAuthAdmin {
-        let client = ReqwestApiClient::new(reqwest::Client::new(), self.credentials.clone());
+        let client = ReqwestApiClient::new(
+            reqwest::Client::new(),
+            self.credentials.clone(),
+            self.project_id.clone(),
+        );
 
         FirebaseAuth::emulated(emulator_url, &self.project_id, client)
     }
@@ -78,7 +82,11 @@ impl App<GcpCredentials> {
 
     /// Create Firebase authentication manager
     pub fn auth(&self) -> LiveAuthAdmin {
-        let client = ReqwestApiClient::new(reqwest::Client::new(), self.credentials.clone());
+        let client = ReqwestApiClient::new(
+            reqwest::Client::new(),
+            self.credentials.clone(),
+            self.project_id.clone(),
+        );
 
         FirebaseAuth::live(&self.project_id, client)
     }


### PR DESCRIPTION
- Using `gcloud` access token to authenticate requests does not work because that token seems not to associate with a particular project ID (unlike service account JSON), even though if we set it via `gcloud config set project` command.
- The solution is to provide project ID via `x-goog-user-project` header for the request as specified via the [documentation](https://cloud.google.com/docs/authentication/troubleshoot-adc#user-creds-client-based).
- Verified that `examples/get_users` works correctly
- Haven't verified, but very unlikely that header would cause any trouble for the case of service account credentials, where no header was provided originally.